### PR TITLE
fix: Fix typo  in WSL full form

### DIFF
--- a/WSL/store-release-notes.md
+++ b/WSL/store-release-notes.md
@@ -12,5 +12,5 @@ ms.localizationpriority: high
 The release notes for [WSL inside of the Microsoft Store](https://aka.ms/wslstorepage) can be found on the [Microsoft/WSL Github repository releases page](https://github.com/microsoft/WSL/releases). Please see that list for latest updates.
 
 ## Known Issues:
-* Launching Windows Subsystem from Linux from session zero does not currently work (for example from an ssh connection).
+* Launching Windows Subsystem for Linux from session zero does not currently work (for example from an ssh connection).
 * The Linux icon in Windows Explorer will only appear if you have the Windows Subsystem for Linux Optional Component installed.


### PR DESCRIPTION
Fixes #1381

Line 15 : Windows Subsystem **from** Linux---> Windows Subsystem **for** Linux
Very subtle but could be confusing for new readers to the documentation